### PR TITLE
Handle File not found error on Create event(Linux)

### DIFF
--- a/source/fswatch.d
+++ b/source/fswatch.d
@@ -363,10 +363,22 @@ struct FileWatch
 					}
 					if ((info.mask & IN_CREATE) != 0)
 					{
-						if (absoluteFileName.isDir && recursive)
+						// If a dir/file is created and deleted immediately then
+						// isDir will throw FileException(ENOENT)
+						try
 						{
-							addWatch(absoluteFileName);
+							if (absoluteFileName.isDir && recursive)
+							{
+								addWatch(absoluteFileName);
+							}
 						}
+						catch (FileException err)
+						{
+							import core.stdc.errno;
+							if (err.errno != ENOENT)
+								throw err;
+						}
+
 						events ~= FileChangeEvent(FileChangeEventType.create, relativeFilename);
 					}
 					if ((info.mask & IN_DELETE) != 0)


### PR DESCRIPTION
If a file is created and deleted immediately, `isDir` check is
failing with FileException. With this patch, error is ignored in
case of ENOENT.

Reproducer: Start the example program and create a file in watched
directory using `vi` editor.

Signed-off-by: Aravinda VK <mail@aravindavk.in>