### PR TITLE
Fix wrong characters in path names in some situations

### DIFF
--- a/source/fswatch.d
+++ b/source/fswatch.d
@@ -357,8 +357,11 @@ struct FileWatch
 				while (true)
 				{
 					auto info = cast(inotify_event*)(eventBuffer.ptr + i);
-					// contains \0 at the end otherwise
-					string fileName = info.name.ptr.fromStringz().idup;
+
+					string fileName = "";
+					if (info.len > 0)
+						fileName = info.name.ptr.fromStringz().idup;
+
 					auto mapIndex = directoryMap.countUntil!(a => a.wd == info.wd);
 					string absoluteFileName = buildPath(directoryMap[mapIndex].path, fileName);
 					string relativeFilename = relativePath("/" ~ absoluteFileName, "/" ~ path);

--- a/source/fswatch.d
+++ b/source/fswatch.d
@@ -276,7 +276,7 @@ struct FileWatch
 		import core.sys.posix.poll : pollfd, poll, POLLIN;
 		import core.stdc.errno : ENOENT;
 		import std.algorithm : countUntil;
-		import std.string : toStringz, fromStringz;
+		import std.string : toStringz, stripRight;
 		import std.conv : to;
 		import std.path : relativePath, buildPath;
 
@@ -357,11 +357,7 @@ struct FileWatch
 				while (true)
 				{
 					auto info = cast(inotify_event*)(eventBuffer.ptr + i);
-
-					string fileName = "";
-					if (info.len > 0)
-						fileName = info.name.ptr.fromStringz().idup;
-
+					string fileName = info.name.ptr[0..info.len].stripRight("\0").idup;
 					auto mapIndex = directoryMap.countUntil!(a => a.wd == info.wd);
 					string absoluteFileName = buildPath(directoryMap[mapIndex].path, fileName);
 					string relativeFilename = relativePath("/" ~ absoluteFileName, "/" ~ path);


### PR DESCRIPTION
When reading inotify_event objects, the code would do `fromStringz` on the `name` field of each event. That field might not exist, in which case the address of `name` is the start of the next inotify_event struct, if there is one. The first field there is `wd`, which in my case was always a small number (starts counting up from 0). Calling `fromStringz` on the 32-bit little-endian integer 1 gives you the string `\x01`, which is then passed to `buildPath`. The end result is you end up with control characters in the path string, or if you have a lot of watches (>20), they start showing up as normal printable characters (e.g. `foo.txt%`).

With this change, the file name is set to an empty string if `len` is 0, otherwise it's passed to `fromStringz` as before.